### PR TITLE
Remove `classnames` dependency and slightly improve performance

### DIFF
--- a/example/app.js
+++ b/example/app.js
@@ -2,6 +2,7 @@ const React = require('react')
 const ReactDOM = require('react-dom')
 const insertCSS = require('insert-css')
 const fs = require('fs')
+const path = require('path')
 const Prism = require('../src/Prism')
 
 const styles = fs.readFileSync(require.resolve('prismjs/themes/prism.css'), 'utf-8')
@@ -10,7 +11,7 @@ insertCSS(styles)
 const app = (
   <div className='app'>
     <h1>react-prism example</h1>
-    <Prism>
+    <Prism language='javascript'>
       {fs.readFileSync(__filename, 'utf-8')}
     </Prism>
   </div>

--- a/example/app.js
+++ b/example/app.js
@@ -2,7 +2,6 @@ const React = require('react')
 const ReactDOM = require('react-dom')
 const insertCSS = require('insert-css')
 const fs = require('fs')
-const path = require('path')
 const Prism = require('../src/Prism')
 
 const styles = fs.readFileSync(require.resolve('prismjs/themes/prism.css'), 'utf-8')

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
     "url": "git+https://github.com/majicloud/react-prism.git"
   },
   "dependencies": {
-    "classnames": "^2.2.5",
     "prop-types": "^15.5.8"
   },
   "peerDependencies": {
@@ -31,9 +30,9 @@
     "babel-preset-stage-0": "^6.24.1",
     "babelify": "^7.3.0",
     "brfs": "^1.4.3",
-    "prismjs": "^1.6.0",
     "budo": "^9.4.7",
     "insert-css": "^2.0.0",
+    "prismjs": "^1.6.0",
     "react": "^15.5.4",
     "react-dom": "^15.5.4",
     "standard": "^10.0.2"

--- a/src/Prism.js
+++ b/src/Prism.js
@@ -1,25 +1,27 @@
 import React, { PureComponent } from 'react'
 import PropTypes from 'prop-types'
-import cx from 'classnames'
 import prism from 'prismjs'
 
 class Prism extends PureComponent {
   static propTypes = {
     children: PropTypes.node.isRequired,
     language: PropTypes.string
-  }
+  };
+
+  setRef = ref => {
+    this.el = ref
+  };
 
   render () {
-    const className = cx({
-      'react-prism': true,
-      [`language-${this.props.language}`]: !!this.props.language
-    })
+    const { language, children } = this.props
+    let className = 'react-prism'
+    if (language) {
+      className += ` language-${language}`
+    }
 
     return (
-      <pre ref={ref => (this.el = ref)} className={className}>
-        <code>
-          {this.props.children}
-        </code>
+      <pre ref={this.setRef} className={className}>
+        <code>{children}</code>
       </pre>
     )
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1329,10 +1329,6 @@ circular-json@^0.3.1:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/circular-json/-/circular-json-0.3.1.tgz#be8b36aefccde8b3ca7aa2d6afc07a37242c0d2d"
 
-classnames@^2.2.5:
-  version "2.2.5"
-  resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.2.5.tgz#fb3801d453467649ef3603c7d61a02bd129bde6d"
-
 cli-cursor@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/cli-cursor/-/cli-cursor-1.0.2.tgz#64da3f7d56a54412e59794bd62dc35295e8f2987"


### PR DESCRIPTION
Rather than creating a new `ref` callback each render, we use a consistent class member. This prevents unecessary reconciliation of children.